### PR TITLE
refactor: update API after server refactor of comment and beta post

### DIFF
--- a/v-beta/src/api/comments.js
+++ b/v-beta/src/api/comments.js
@@ -28,7 +28,7 @@ export async function postCommentForUser(user, problemId, commentInfo) {
  * Delete user comment from a problem.
  * 
  * @param {import("firebase/auth").User} user
- * @param {authorId: number, problemId: number, commentContent: string} payload
+ * @param {{authorId: number, problemId: number, discussionId: number, commentContent: string}} payload
  */
 export async function deleteUserComment(user, payload){
   const idToken = await user.getIdToken();

--- a/v-beta/src/api/solutionBeta.js
+++ b/v-beta/src/api/solutionBeta.js
@@ -105,7 +105,7 @@ export async function saveSolutionBetaToDatabase(user, payload) {
  * Delete solution beta from database.
  *
  * @param {import("firebase/auth").User} user
- * @param {{userId: number, problemId: number, publicUrl: string}} payload
+ * @param {{userId: number, problemId: number, discussionId: number, publicUrl: string}} payload
  */
 export async function deleteSolutionBetaFromDatabase(user, payload) {
     const idToken = await user.getIdToken();

--- a/v-beta/src/app/wall/[wallSectionID]/problem/[problemId]/page.js
+++ b/v-beta/src/app/wall/[wallSectionID]/problem/[problemId]/page.js
@@ -97,6 +97,39 @@ function parsePositiveNumberId(raw) {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
+/** @param {unknown} discussionItem */
+function getDiscussionId(discussionItem) {
+  if (!discussionItem || typeof discussionItem !== 'object') return null;
+  const discussionRecord = /** @type {Record<string, unknown>} */ (discussionItem);
+  const discussionId =
+    discussionRecord.discussionId ?? discussionRecord.id ?? discussionRecord.commentId;
+  return parsePositiveNumberId(discussionId);
+}
+
+/** @param {unknown} discussionItem */
+function getDiscussionContent(discussionItem) {
+  if (!discussionItem || typeof discussionItem !== 'object') return '';
+  const discussionRecord = /** @type {Record<string, unknown>} */ (discussionItem);
+  const value = discussionRecord.discussionContent ?? discussionRecord.comment ?? '';
+  return typeof value === 'string' ? value : '';
+}
+
+/** @param {unknown} discussionItem */
+function getDiscussionType(discussionItem) {
+  if (!discussionItem || typeof discussionItem !== 'object') return '';
+  const discussionRecord = /** @type {Record<string, unknown>} */ (discussionItem);
+  const value = discussionRecord.discussionType;
+  return typeof value === 'string' ? value.toUpperCase() : '';
+}
+
+/** @param {unknown} discussionItem */
+function getDiscussionMediaUrl(discussionItem) {
+  if (!discussionItem || typeof discussionItem !== 'object') return '';
+  const discussionRecord = /** @type {Record<string, unknown>} */ (discussionItem);
+  const value = discussionRecord.videoURL ?? discussionRecord.discussionContent ?? '';
+  return typeof value === 'string' ? value : '';
+}
+
 function buildShortUploadFileName(originalFileName, problemId) {
   const name = (originalFileName || '').toLowerCase();
   const extension = name.endsWith('.webm') ? 'webm' : 'mp4';
@@ -157,8 +190,9 @@ export default function ProblemPage() {
     }
 
     const payloadAuthorId = parsePositiveNumberId(authorId);
-    const commentContent = targetComment?.comment?.trim();
-    if (!payloadAuthorId || !commentContent) {
+    const discussionId = getDiscussionId(targetComment);
+    const commentContent = getDiscussionContent(targetComment).trim();
+    if (!payloadAuthorId || !discussionId || !commentContent) {
       toast.error("Unable to determine comment payload for deletion.");
       return;
     }
@@ -167,6 +201,7 @@ export default function ProblemPage() {
       await deleteUserComment(user, {
         authorId: payloadAuthorId,
         problemId,
+        discussionId,
         commentContent,
       });
       await refreshProblem();
@@ -177,9 +212,11 @@ export default function ProblemPage() {
   };
 
   const handleDeleteSolutionBeta = async (targetComment) => {
-    if (!targetComment || !targetComment.videoURL || !user || !problemId) {
+    if (!targetComment || !user || !problemId) {
       return;
     }
+    const mediaUrl = getDiscussionMediaUrl(targetComment);
+    if (!mediaUrl) return;
 
     const authorId = getCommentAuthorId(targetComment);
     const canDeleteSolutionBeta =
@@ -189,7 +226,8 @@ export default function ProblemPage() {
     }
 
     const payloadUserId = parsePositiveNumberId(authorId);
-    if (!payloadUserId) {
+    const discussionId = getDiscussionId(targetComment);
+    if (!payloadUserId || !discussionId) {
       toast.error('Unable to determine owner id for solution beta deletion.');
       return;
     }
@@ -198,7 +236,8 @@ export default function ProblemPage() {
       await deleteSolutionBetaFromDatabase(user, {
         userId: payloadUserId,
         problemId,
-        publicUrl: targetComment.videoURL,
+        discussionId,
+        publicUrl: mediaUrl,
       });
       await refreshProblem();
       clearSelectedSolutionFile();
@@ -528,17 +567,23 @@ export default function ProblemPage() {
                   {problem.discussion.map((comment, index) =>
                     (() => {
                       const authorId = getCommentAuthorId(comment);
+                      const discussionType = getDiscussionType(comment);
+                      const discussionContent = getDiscussionContent(comment);
+                      const mediaUrl = getDiscussionMediaUrl(comment);
                       const canDeleteComment =
                         isAdmin ||
                         (!!currentUserId &&
                           !!authorId &&
                           currentUserId === authorId);
                       const isSolutionBeta =
-                        comment.comment == null && !!comment.videoURL;
+                        discussionType === 'BETA' ||
+                        (discussionType !== 'COMMENT' &&
+                          !discussionContent &&
+                          !!mediaUrl);
                       return (
                         <article
                           key={
-                            comment.videoURL ||
+                            mediaUrl ||
                             `${comment.username || 'anonymous'}-${
                               comment.createdDate || index
                             }-${index}`
@@ -612,7 +657,7 @@ export default function ProblemPage() {
                               </DropdownMenu>
                             )}
                           </div>
-                          {comment.comment == null && comment.videoURL ? (
+                          {isSolutionBeta ? (
                             <details>
                               <summary
                                 style={{
@@ -637,8 +682,8 @@ export default function ProblemPage() {
                                   }}
                                 >
                                   <source
-                                    src={comment.videoURL}
-                                    type={inferVideoMimeType(comment.videoURL)}
+                                    src={mediaUrl}
+                                    type={inferVideoMimeType(mediaUrl)}
                                   />
                                   Your browser does not support the video tag.
                                 </video>
@@ -652,7 +697,7 @@ export default function ProblemPage() {
                                 lineHeight: 1.5,
                               }}
                             >
-                              {comment.comment || ''}
+                              {discussionContent}
                             </p>
                           )}
                         </article>

--- a/v-beta/src/app/wall/[wallSectionID]/problem/[problemId]/problem-page.test.js
+++ b/v-beta/src/app/wall/[wallSectionID]/problem/[problemId]/problem-page.test.js
@@ -108,16 +108,22 @@ const baseProblem = {
 };
 
 const commentByOwner = {
+  discussionId: 301,
+  userId: 5,
+  discussionType: "COMMENT",
+  discussionContent: "Try heel hook",
   username: "owner",
   createdDate: "2026-04-26T12:00:00.000Z",
-  authorId: 5,
   comment: "Try heel hook",
 };
 
 const betaByOwner = {
+  discussionId: 302,
+  userId: 5,
+  discussionType: "BETA",
+  discussionContent: "https://example.com/beta.mp4",
   username: "owner",
   createdDate: "2026-04-26T12:01:00.000Z",
-  authorId: 5,
   comment: null,
   videoURL: "https://example.com/beta.mp4",
 };
@@ -262,6 +268,7 @@ describe("ProblemPage coverage", () => {
         expect(deleteUserComment).toHaveBeenCalledWith(user, {
           authorId: 5,
           problemId: 100,
+          discussionId: 301,
           commentContent: "Try heel hook",
         });
       });
@@ -326,7 +333,13 @@ describe("ProblemPage coverage", () => {
         account: adminAccount,
         problem: {
           ...baseProblem,
-          discussion: [{ ...commentByOwner, authorId: "not-a-number" }],
+          discussion: [
+            {
+              ...commentByOwner,
+              authorId: "not-a-number",
+              userId: "not-a-number",
+            },
+          ],
         },
       });
       await screen.findByText("Try heel hook");


### PR DESCRIPTION
## Linked Issue
Related to #23 

## Sub-Issue (Frontend): Align Discussion UI/API with `DiscussionRoot` Contract

### Merge Strategy
- **Base branch:** `refactor/service_repo`
- This PR is the frontend counterpart to the server-side `DiscussionRoot` refactor and is **not intended to merge directly into `main`** yet.
- It should merge into `refactor/service_repo` after (or alongside) the server PR so both layers are validated together.
- Once both server + frontend discussion-path migrations are integrated and verified, `refactor/service_repo` can be promoted to `main`.

### Summary
This PR updates the climbing problem frontend discussion flows to match the server’s unified `DiscussionRoot` lifecycle contract.  
It aligns payload handling and UI rendering with `discussionId`, `discussionType`, and `discussionContent`, and updates tests to validate the new delete/request expectations.

### Problem
Frontend discussion behavior relied on legacy fields and delete payloads that did not include `discussionId`.  
After the server refactor, this caused contract drift risk for comment/beta rendering and deletion operations.

### Scope
- Align frontend discussion delete payloads with server requirements (`discussionId` included)
- Support refactored discussion response fields in UI logic:
  - `discussionId`
  - `discussionType`
  - `discussionContent`
- Keep backward compatibility with legacy frontend/server field shapes where possible
- Update tests to validate refactor-aligned behavior

### Out of Scope
- New discussion endpoints
- Server-side business logic or schema changes
- Full threaded reply UI rollout
- Non-discussion feature changes outside the problem page context

### What Changed

- **Discussion contract alignment on problem page**
  - Updated `v-beta/src/app/wall/[wallSectionID]/problem/[problemId]/page.js`
  - Added normalization helpers for `discussionId`, `discussionType`, `discussionContent`, and beta media URL fallback.
  - Updated comment delete flow to send:
    - `authorId`
    - `problemId`
    - `discussionId`
    - `commentContent`
  - Updated solution beta delete flow to send:
    - `userId`
    - `problemId`
    - `discussionId`
    - `publicUrl`
  - Updated rendering/classification logic to treat `discussionType === BETA` as source of truth, while preserving safe legacy fallbacks.

- **Frontend API contract docs/types updates**
  - Updated payload JSDoc expectations in:
    - `v-beta/src/api/comments.js`
    - `v-beta/src/api/solutionBeta.js`

- **Test coverage updates**
  - Updated `v-beta/src/app/wall/[wallSectionID]/problem/[problemId]/problem-page.test.js` fixtures and assertions to reflect refactored discussion contract.
  - Added expectation coverage for `discussionId` in comment deletion payload path.
  - Preserved negative-path validation for malformed author identifiers.

### Acceptance Criteria
- [x] Problem discussion UI accepts and renders refactored discussion fields
- [x] Comment and beta deletions include `discussionId` in request payloads
- [x] Owner/admin delete behavior remains intact in frontend gating logic
- [x] Backward-compatible fallbacks remain in place for legacy response shapes
- [x] Targeted frontend test suite passes for problem page discussion flows

### Test Evidence
- Command run:
  - `npm test -- --runInBand --runTestsByPath "src/app/wall/[wallSectionID]/problem/[problemId]/problem-page.test.js"`
- Result:
  - `1 passed, 1 total` suites
  - `18 passed, 18 total` tests
- Lint diagnostics on touched files: no errors reported

### Dependencies
- Depends on the server refactor PR for Issue #22 
- Targets integration branch: `refactor/service_repo`